### PR TITLE
feat: configure contract address via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Environment variables for Give-A-Wonderful-Day DApp
+# Copy this file to .env.local and fill in the values before running the app.
+
+# Deployed NonprofitDonation contract address
+NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS=0xYourContractAddressHere

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ a proposed 501(c)(3) nonprofit organization dedicated to bringing joy and respit
 ## Smart Contracts
 - `contracts/NonprofitDonation.sol`: Core contract for transparent donations and fund management.
 
+## Launching the DApp
+1. Install dependencies with `npm install`.
+2. Copy `.env.example` to `.env.local` and set `NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS` to your deployed contract address.
+3. Run `npm run dev` for local development or `npm run build && npm start` to serve the production build.
+
 ## Next Steps
 1. Add frontend DApp for donations and dashboards
 2. Expand smart contracts for NFTs, matching funds, and DAO governance

--- a/app/contract/nonprofit.ts
+++ b/app/contract/nonprofit.ts
@@ -1,7 +1,10 @@
 import { ethers } from "ethers";
 
-// Replace with your deployed contract address
-export const NONPROFIT_CONTRACT_ADDRESS = "0xYourContractAddressHere";
+// Contract address is injected via environment variable for flexibility across
+// deployments. Use a NEXT_PUBLIC_ prefix so the value is available in the
+// browser bundle.
+export const NONPROFIT_CONTRACT_ADDRESS =
+  process.env.NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS || "";
 
 export const NONPROFIT_CONTRACT_ABI = [
   "function donate(string message) payable",
@@ -10,6 +13,11 @@ export const NONPROFIT_CONTRACT_ABI = [
 ];
 
 export function getContract(signerOrProvider) {
+  if (!NONPROFIT_CONTRACT_ADDRESS) {
+    throw new Error(
+      "NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS is not set"
+    );
+  }
   return new ethers.Contract(
     NONPROFIT_CONTRACT_ADDRESS,
     NONPROFIT_CONTRACT_ABI,

--- a/app/contract/nonprofit.ts
+++ b/app/contract/nonprofit.ts
@@ -12,9 +12,11 @@ export const NONPROFIT_CONTRACT_ABI = [
   "event DonationReceived(address indexed donor, uint256 amount, string message, uint256 timestamp)"
 ];
 
-export function getContract(signerOrProvider) {
-  if (!NONPROFIT_CONTRACT_ADDRESS) {
-    throw new Error(
+if (!NONPROFIT_CONTRACT_ADDRESS || !ethers.utils.isAddress(NONPROFIT_CONTRACT_ADDRESS)) {
+  throw new Error(
+    "NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS is not set or is not a valid Ethereum address"
+  );
+}
       "NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS is not set"
     );
   }


### PR DESCRIPTION
## Summary
- read NonprofitDonation contract address from NEXT_PUBLIC_NONPROFIT_CONTRACT_ADDRESS
- document launch steps and provide .env.example template

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c51a010e48832d9d433e7ab8344274